### PR TITLE
MOM_domain_infra: Document FMS passthroughs

### DIFF
--- a/src/framework/MOM_domain_infra.F90
+++ b/src/framework/MOM_domain_infra.F90
@@ -7,11 +7,11 @@ use MOM_coms_infra,  only : PE_here, root_PE, num_PEs
 use MOM_cpu_clock,   only : cpu_clock_begin, cpu_clock_end
 use MOM_error_infra, only : MOM_error=>MOM_err, NOTE, WARNING, FATAL
 
-use mpp_domains_mod, only : domain2D, domain1D, group_pass_type => mpp_group_update_type
+use mpp_domains_mod, only : domain2D, domain1D
 use mpp_domains_mod, only : mpp_define_io_domain, mpp_define_domains, mpp_deallocate_domain
 use mpp_domains_mod, only : mpp_get_domain_components, mpp_get_domain_extents
 use mpp_domains_mod, only : mpp_get_compute_domain, mpp_get_data_domain, mpp_get_global_domain
-use mpp_domains_mod, only : mpp_get_boundary, mpp_update_domains, global_field_sum => mpp_global_sum
+use mpp_domains_mod, only : mpp_get_boundary, mpp_update_domains
 use mpp_domains_mod, only : mpp_start_update_domains, mpp_complete_update_domains
 use mpp_domains_mod, only : mpp_create_group_update, mpp_do_group_update
 use mpp_domains_mod, only : mpp_reset_group_update_field, mpp_group_update_initialized
@@ -25,6 +25,12 @@ use mpp_domains_mod, only : To_North => SUPDATE, To_South => NUPDATE
 use mpp_domains_mod, only : CENTER, CORNER, NORTH_FACE => NORTH, EAST_FACE => EAST
 use fms_io_mod,      only : file_exist, parse_mask_table
 use fms_affinity_mod, only : fms_affinity_init, fms_affinity_set, fms_affinity_get
+
+! This subroutine is not in MOM6/src but may be required by legacy drivers
+use mpp_domains_mod, only : global_field_sum => mpp_global_sum
+
+! The `group_pass_type` fields are never accessed, so we keep it as an FMS type
+use mpp_domains_mod, only : group_pass_type => mpp_group_update_type
 
 implicit none ; private
 


### PR DESCRIPTION
This patch explicitly identifies `global_field_sum` and
`group_pass_type` as FMS pass-throughs.  These remain undocumented and
cannot be wrapped, but the exceptional reasons for retaining them
justifies their existence as pass-throughs.

Since `global_field_sum` is unused in MOM6/src, it does not require an
explicit definition or wrapper.  Legacy drivers may still require this
definition, however, so we retain it here.

The contents of `group_pass_type` are never accessed, and it is only
used to facilitate internal mpp operations, so it does not need to
formally be part of the MOM6 API and can be left undocumented.

Since these two functions are exceptions to the rule that all active
operations should be wrapped and documented, it makes sense to
explicitly identify them as such.